### PR TITLE
Keybindings available in other filetypes after quicktask filetype is opened

### DIFF
--- a/ftplugin/quicktask.vim
+++ b/ftplugin/quicktask.vim
@@ -953,20 +953,20 @@ endfunction
 
 " ============================================================================
 " Key mappings {{{1
-nmap <Leader>tv :call <SID>SelectTask()<CR>
-nmap <Leader>tD :call <SID>TaskComplete()<CR>
-nmap <Leader>ta :call <SID>ShowActiveTasksOnly()<CR>
-nmap <Leader>tw :call <SID>ShowWatchedTasksOnly()<CR>
-nmap <Leader>ty :call <SID>ShowTodayTasksOnly()<CR>
-nmap <Leader>ts :call <SID>AddNextTimeToTask()<CR>
-nmap <Leader>tO :call <SID>AddTaskAbove()<CR>
-nmap <Leader>to :call <SID>AddTaskBelow()<CR>
-nmap <Leader>tc :call <SID>AddChildTask()<CR>
-nmap <Leader>tu :call <SID>MoveTaskUp()<CR>
-nmap <Leader>td :call <SID>MoveTaskDown()<CR>
-nmap <Leader>tS :call <SID>AddSnipToTask()<CR>
-nmap <Leader>tj :call <SID>JumpToSnip()<CR>
-nmap <Leader>tfi :call <SID>FindIncompleteTimestamps()<CR>:silent set hlsearch \| echo<CR>
+nmap <buffer> <Leader>tv :call <SID>SelectTask()<CR>
+nmap <buffer> <Leader>tD :call <SID>TaskComplete()<CR>
+nmap <buffer> <Leader>ta :call <SID>ShowActiveTasksOnly()<CR>
+nmap <buffer> <Leader>tw :call <SID>ShowWatchedTasksOnly()<CR>
+nmap <buffer> <Leader>ty :call <SID>ShowTodayTasksOnly()<CR>
+nmap <buffer> <Leader>ts :call <SID>AddNextTimeToTask()<CR>
+nmap <buffer> <Leader>tO :call <SID>AddTaskAbove()<CR>
+nmap <buffer> <Leader>to :call <SID>AddTaskBelow()<CR>
+nmap <buffer> <Leader>tc :call <SID>AddChildTask()<CR>
+nmap <buffer> <Leader>tu :call <SID>MoveTaskUp()<CR>
+nmap <buffer> <Leader>td :call <SID>MoveTaskDown()<CR>
+nmap <buffer> <Leader>tS :call <SID>AddSnipToTask()<CR>
+nmap <buffer> <Leader>tj :call <SID>JumpToSnip()<CR>
+nmap <buffer> <Leader>tfi :call <SID>FindIncompleteTimestamps()<CR>:silent set hlsearch \| echo<CR>
 " I don't know if this is rude.
 nnoremap <buffer> <CR> :call OpenSnip()<CR>
 


### PR DESCRIPTION
I was able to reproduce this issue by doing the following:
1. create a test file like `test.php`
2. use `:QTinit` to save a a basic quicktask file `notes.txt`
3. reload vim
4. `:e test.php`
   - verify that `<leader>to` does not insert a task line
5. `:e notes.txt`
   - verify that `<leader>to` and other keybindings work
6. Swap back to `test.php`
7. `<leader>to` still enters a new note line

I think what's intended is that those key bindings should only work with quicktask files.  But it might be useful for comments in other code, maybe an option for the user to decide?

My commit fixed this for me, but I know very little about vimscript.
