### PR TITLE
Remove trailing space - please pull.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ Quicktask is designed to be deployed as a Pathogen (or Vundle, etc.) bundle. Typ
 If you do not use Git to manage your Vim configuration, you can simply clone the repository into your `bundles` folder:
 
 ```
-$ cd ~/.vim  
+$ cd ~/.vim
 $ git clone https://github.com/aaronbieber/quicktask.git bundles/quicktask
 ```
 
 If you *do* use Git to manage your Vim configuration and you want to add Quicktask as a submodule, you would instead run these commands:
 
 ```
-$ cd ~/.vim  
-$ git submodule add https://github.com/aaronbieber/quicktask.git bundles/quicktask  
-$ git submodule init  
+$ cd ~/.vim
+$ git submodule add https://github.com/aaronbieber/quicktask.git bundles/quicktask
+$ git submodule init
 $ git submodule update
 ```
 

--- a/doc/quicktask.txt
+++ b/doc/quicktask.txt
@@ -17,26 +17,26 @@
 ===============================================================================
 1. Introduction					*quicktask-introduction*
 
-Quicktask is inspired in no small part by Eric Talevich's "todolist" syntax 
-highlighting scheme. Though some of the concepts and syntax patterns are 
-borrowed from that work, Quicktask is a filetype plugin that provides 
-unique functionality for working with simple lists of tasks that aren't 
+Quicktask is inspired in no small part by Eric Talevich's "todolist" syntax
+highlighting scheme. Though some of the concepts and syntax patterns are
+borrowed from that work, Quicktask is a filetype plugin that provides
+unique functionality for working with simple lists of tasks that aren't
 found anywhere else in Vim.
 
-Quicktask is not org-mode, nor is it a fully-featured personal information 
-manager. You will get the most out of Quicktask if your work is broken into 
+Quicktask is not org-mode, nor is it a fully-featured personal information
+manager. You will get the most out of Quicktask if your work is broken into
 distinct assignments that have relatively simple definitions.
 
 ===============================================================================
 2. Getting Started				*quicktask-getting-started*
 
-The first thing you will want to do is create a new Quicktask file. Open a 
-fresh Vim instance and call the command QTInit (you would type :QTInit<CR>).  
-If you run this command in a Vim instance with a file open in the current 
-buffer, a new buffer will be split and the Quicktask file will be created 
+The first thing you will want to do is create a new Quicktask file. Open a
+fresh Vim instance and call the command QTInit (you would type :QTInit<CR>).
+If you run this command in a Vim instance with a file open in the current
+buffer, a new buffer will be split and the Quicktask file will be created
 there.
 
-You will be greeted with a very barebones task list with two sections, 
+You will be greeted with a very barebones task list with two sections,
 "current tasks" and "completed tasks," as well as a single "starter" task.
 
 The layout of a Quicktask file is straightforward:
@@ -46,7 +46,7 @@ Sections or Projects					*quicktask-sections*
 			CURRENT TASKS:
 <
 Tasks							*quicktask-tasks*
-		Begin with a hyphen followed by a space, and may have "notes" 
+		Begin with a hyphen followed by a space, and may have "notes"
 		or other tasks nested beneath them. Example: >
 			CURRENT TASKS:
 			  - A task
@@ -54,20 +54,20 @@ Tasks							*quicktask-tasks*
 			    - A second task
 <
 Notes							*quicktask-notes*
-		Begin with an asterisk and usually appear within tasks, though 
-		they are not required to.  See the example above, 
+		Begin with an asterisk and usually appear within tasks, though
+		they are not required to.  See the example above,
 		|quicktask-tasks|.
 
-The hierarchy of information is expressed through indentation and the 
-indentation has semantic meaning to Quicktask. For example, you can move tasks 
-up and down among their peers, expand and collapse tasks to hide or reveal all 
+The hierarchy of information is expressed through indentation and the
+indentation has semantic meaning to Quicktask. For example, you can move tasks
+up and down among their peers, expand and collapse tasks to hide or reveal all
 of their sub-tasks, and so on.
 
 ===============================================================================
 3. Keyboard Shortcuts				*quicktask-keyboard-shortcuts*
 
-Nearly all of Quicktask's functionality is exposed through keyboard shortcuts 
-(or "mappings" in Vim parlance). All Quicktask mappings begin with <Leader>t 
+Nearly all of Quicktask's functionality is exposed through keyboard shortcuts
+(or "mappings" in Vim parlance). All Quicktask mappings begin with <Leader>t
 which is short for "task."
 
 <Leader>to	Insert a new task below the current task (similar to how
@@ -80,65 +80,65 @@ which is short for "task."
 		the current task.
 
 <Leader>ts	Add start or end time stamps to the current task (mnemonic:
-		"timestamp", "task start", or "time start"). A new note will 
-		be added to the current task with today's date and a timestamp 
-		reading "Start." If there is already a note with a start time, 
-		an end time will be added to it. If there is already a 
-		complete start and end item, a new one will be added. By 
-		pressing <Leader>ts repeatedly, you can log the start and stop 
+		"timestamp", "task start", or "time start"). A new note will
+		be added to the current task with today's date and a timestamp
+		reading "Start." If there is already a note with a start time,
+		an end time will be added to it. If there is already a
+		complete start and end item, a new one will be added. By
+		pressing <Leader>ts repeatedly, you can log the start and stop
 		progress of a task.
 
 <Leader>tu	Move the current task up (mnemonic: "task up"). Tasks can only
-		be moved up and down among sibling tasks, so they will not 
+		be moved up and down among sibling tasks, so they will not
 		move between sections (projects).
 
 <Leader>td	Move the current task down (mnemonic: "task down"). Tasks can
-		only be moved up and down among sibling tasks, so they will 
+		only be moved up and down among sibling tasks, so they will
 		not move between sections (projects).
 
 <Leader>tD	Mark a task as "done." This adds a new "note" line at the end
-		of the task with the "DONE" keyword and a timestamp. It is 
-		important to keep in mind that the "DONE" keyword has meaning 
+		of the task with the "DONE" keyword and a timestamp. It is
+		important to keep in mind that the "DONE" keyword has meaning
 		to Quicktask.
 
-<Leader>ta	Show (unfold) active tasks only. This has the effect of 
+<Leader>ta	Show (unfold) active tasks only. This has the effect of
 		closing all of the folds in your task list and only expanding
-		the ones that do not have a "DONE" keyword in them (and their 
-		parents). If an incomplete task has completed child tasks, 
-		only the completed child tasks will be folded. The goal is to 
-		instantly present a filtered view of active items that need 
+		the ones that do not have a "DONE" keyword in them (and their
+		parents). If an incomplete task has completed child tasks,
+		only the completed child tasks will be folded. The goal is to
+		instantly present a filtered view of active items that need
 		attention.
 
-<Leader>ty	Show (unfold) tasks containing today's date. This mapping only 
-		works when you have used the Quicktask date stamp format for 
-		the date, as it is a pattern-based match. This would unfold 
+<Leader>ty	Show (unfold) tasks containing today's date. This mapping only
+		works when you have used the Quicktask date stamp format for
+		the date, as it is a pattern-based match. This would unfold
 		items that were added OR completed today.
 
 <Leader>tv	Visually select the current task. This allows you to very
-		quickly use Vim's own yank/delete/put commands to move tasks 
-		around to other sections or copy them to the system clipboard, 
+		quickly use Vim's own yank/delete/put commands to move tasks
+		around to other sections or copy them to the system clipboard,
 		etc.
 
 <Leader>tfi	Find incomplete timestamps (mnemonic: "task find incomplete").
-		This mapping actually performs a search for progress lines 
-		(inserted with <Leader>ts) that have a start time but no end 
-		time (presumed to be "incomplete"), which may not result in a 
-		visible change to the buffer, though it WILL force search 
-		highlighting to be turned on (see |hlsearch|). You can then 
+		This mapping actually performs a search for progress lines
+		(inserted with <Leader>ts) that have a start time but no end
+		time (presumed to be "incomplete"), which may not result in a
+		visible change to the buffer, though it WILL force search
+		highlighting to be turned on (see |hlsearch|). You can then
 		use "n" and "N" to navigate among the found lines.
 
 ===============================================================================
 4. Abbreviations				*quicktask-abbreviations*
 
-Abbreviations in Vim are used to replace a string with another while entering 
-text. Quicktask uses Insert-mode abbreviations to provide an easy way to add 
-datestamps and timestamps to your task lists. The following abbreviations are 
-available (for information on how to use abbreviations, see |abbreviations| in 
-the Vim manual). All dates are inserted in the Quicktask standard datestamp 
+Abbreviations in Vim are used to replace a string with another while entering
+text. Quicktask uses Insert-mode abbreviations to provide an easy way to add
+datestamps and timestamps to your task lists. The following abbreviations are
+available (for information on how to use abbreviations, see |abbreviations| in
+the Vim manual). All dates are inserted in the Quicktask standard datestamp
 format, e.g.: >
 	[Wed 2012-01-18]
 <
-All abbreviations begin with the at ("@") symbol, which is remembered easily 
+All abbreviations begin with the at ("@") symbol, which is remembered easily
 through the mnemonic of entering a stamp "at" a particular time.
 
 @today		Inserts today's date.
@@ -151,32 +151,32 @@ through the mnemonic of entering a stamp "at" a particular time.
 ===============================================================================
 5. Using Snips					*quicktask-using-snips*
 
-Snips are a way for you to attach freeform information to task entries.  
-Fundamentally snips are text files, but there is no limitation to what 
+Snips are a way for you to attach freeform information to task entries.
+Fundamentally snips are text files, but there is no limitation to what
 formats the files can be saved in.
 
 Snips are attached to tasks with a special snip note that looks like: >
 	* [$: 1234121212-task-name]
 <
-The first part of the name is a timestamp to ensure that the name is unique 
-and the second part is taken from the text of the current task so that the 
-file names hopefully have some contextual meaning outside of the Quicktask 
+The first part of the name is a timestamp to ensure that the name is unique
+and the second part is taken from the text of the current task so that the
+file names hopefully have some contextual meaning outside of the Quicktask
 file itself.
 
-To start using snips, you must first configure the path to where you want your 
-snips to be saved. Do this by configuring g:quicktask_snip_path in your 
-.vimrc. The path must be absolute! For example, it might look like one of 
+To start using snips, you must first configure the path to where you want your
+snips to be saved. Do this by configuring g:quicktask_snip_path in your
+.vimrc. The path must be absolute! For example, it might look like one of
 these: >
 	let g:quicktask_snip_path = '~/snips'
 	let g:quicktask_snip_path = 'c:\snips'
 <
-When you open or begin a new Quicktask file, Quicktask will check to see if 
-the directory exists and if it doesn't, it will ask you if you would like it 
+When you open or begin a new Quicktask file, Quicktask will check to see if
+the directory exists and if it doesn't, it will ask you if you would like it
 to be created.
 
-To add a new snip to a task, simply press <Leader>tS (with a capital "S"). The 
-snip note is added to the current task and the file is opened for editing.  
-There are a variety of options available for how that process is handled; see 
+To add a new snip to a task, simply press <Leader>tS (with a capital "S"). The
+snip note is added to the current task and the file is opened for editing.
+There are a variety of options available for how that process is handled; see
 |quicktask-options| below.
 
 ===============================================================================
@@ -185,70 +185,70 @@ There are a variety of options available for how that process is handled; see
 Quicktask only has one option at the moment.
 
 g:quicktask_autosave				*g:quicktask_autosave*
-		If set to true (a non-zero number, such as 1), Quicktask will 
-		attempt to save the current list file when the window loses 
-		focus or you switch buffers.  This only works in Vim editors 
-		that respond to the BufLeave or FocusLost events (to my 
-		knowledge, FocusLost is supported by the graphical variants of 
+		If set to true (a non-zero number, such as 1), Quicktask will
+		attempt to save the current list file when the window loses
+		focus or you switch buffers.  This only works in Vim editors
+		that respond to the BufLeave or FocusLost events (to my
+		knowledge, FocusLost is supported by the graphical variants of
 		Vim and BufLeave is supported by all Vims). >
 			let g:quicktask_autosave = 1
 <
-		If the current list file is not saved somewhere, the autosave 
+		If the current list file is not saved somewhere, the autosave
 		will silently fail! Keep that in mind.
 
 g:quicktask_snip_path				*g:quicktask_snip_path*
-		You must configure this option in order to use snips (see 
-		|quicktask-using-snips|). The option must be set to an 
-		absolute path on disk where you would like your snip files to 
-		be saved. For the moment, all snips from all Quicktask lists 
+		You must configure this option in order to use snips (see
+		|quicktask-using-snips|). The option must be set to an
+		absolute path on disk where you would like your snip files to
+		be saved. For the moment, all snips from all Quicktask lists
 		are stored in the same location.
 
 g:quicktask_snip_win_maximize			*g:quicktask_snip_win_maximize*
-		If set to 1, the snip window will be opened at full size. The 
+		If set to 1, the snip window will be opened at full size. The
 		default is 0.
 
 g:quicktask_snip_win_height			*g:quicktask_snip_win_height*
-		If set to any numeric value, the snip window will open with 
-		the number of lines or columns given. Note that if 
-		|g:quicktask_snip_win_maximize| is set, this option will have 
+		If set to any numeric value, the snip window will open with
+		the number of lines or columns given. Note that if
+		|g:quicktask_snip_win_maximize| is set, this option will have
 		no effect.
 
 g:quicktask_snip_default_filetype
 					    *g:quicktask_snip_default_filetype*
-		Set this option to the filetype that snips should be created 
-		as. If you do not specify a filetype, "text" will be used. The 
-		default filetype is helpfully written into a modeline at the 
-		end of new snip files. Feel free to change it; Quicktask won't 
+		Set this option to the filetype that snips should be created
+		as. If you do not specify a filetype, "text" will be used. The
+		default filetype is helpfully written into a modeline at the
+		end of new snip files. Feel free to change it; Quicktask won't
 		override you.
 
 g:quicktask_snip_win_split_direction	*g:quicktask_snip_win_split_direction*
-		This option tells Quicktask which way to split the window when 
-		you open or create a snip. The default is horizontal and the only 
-		other valid option is "vertical." If you specify anything else, or 
+		This option tells Quicktask which way to split the window when
+		you open or create a snip. The default is horizontal and the only
+		other valid option is "vertical." If you specify anything else, or
 		leave it blank, the window will split horizontally.
 
 ===============================================================================
 7. Organizing Tasks				*quicktask-organizing-tasks*
 
-The philosophy of Quicktask is to provide a simple and versatile feature set 
-that each user can apply in their own way. Although some of the formatting and 
-keywords cannot be changed, there are innumerble ways in which to build and 
-manage a list of tasks. This section briefly covers some of the core concepts 
+The philosophy of Quicktask is to provide a simple and versatile feature set
+that each user can apply in their own way. Although some of the formatting and
+keywords cannot be changed, there are innumerble ways in which to build and
+manage a list of tasks. This section briefly covers some of the core concepts
 that I have found useful and that I hope you do, too.
 
-I like to keep a section of "current tasks" representing pending work. With 
-Quicktask, it's easy to add a new task to the list with <Leader>to and begin 
-working on it with <Leader>ts. When I have completed my work, or get pulled 
+I like to keep a section of "current tasks" representing pending work. With
+Quicktask, it's easy to add a new task to the list with <Leader>to and begin
+working on it with <Leader>ts. When I have completed my work, or get pulled
 into another task, I can press <Leader>ts to stop progress.
 
-As I complete tasks, I just press <Leader>tD to mark them as "DONE" and move 
-on to the next assignment. At the end of the day or week, I press <Leader>ta 
-to collapse all of the completed tasks and move them into "completed tasks." 
-Because I perform a lot of smaller tasks, I have created a "completed tasks" 
-section for each year, e.g. "COMPLETED TASKS (2011):", just to keep things 
+As I complete tasks, I just press <Leader>tD to mark them as "DONE" and move
+on to the next assignment. At the end of the day or week, I press <Leader>ta
+to collapse all of the completed tasks and move them into "completed tasks."
+Because I perform a lot of smaller tasks, I have created a "completed tasks"
+section for each year, e.g. "COMPLETED TASKS (2011):", just to keep things
 more organized.
 
-There is no reason not to create any sections or project groupings you can 
+There is no reason not to create any sections or project groupings you can
 imagine, including nested sections.
 
 ===============================================================================
@@ -256,35 +256,35 @@ imagine, including nested sections.
 
 8.1 Setting the Filetype			*quicktask-adv-filetype*
 
-Quicktask is a filetype plugin (ftplugin), meaning that it is reliant on the 
-filetype of the current file in order to operate. The Quicktask filetype is 
-simply "quicktask" and, when set, Vim will load the Quicktask code and make 
+Quicktask is a filetype plugin (ftplugin), meaning that it is reliant on the
+filetype of the current file in order to operate. The Quicktask filetype is
+simply "quicktask" and, when set, Vim will load the Quicktask code and make
 its commands available to you.
 
-When you create a new Quicktask list with QTInit, a "modeline" is placed at 
-the end of the file. The modeline will cause Vim to treat the file as a 
-Quicktask-type file no matter what you name it (for information on modelines, 
-read |modeline|). If modelines are disabled in your configuration, you may 
-want to use another method to conveniently re-set the filetype of your 
-Quicktask files. One common way to achieve that is with a file extension 
+When you create a new Quicktask list with QTInit, a "modeline" is placed at
+the end of the file. The modeline will cause Vim to treat the file as a
+Quicktask-type file no matter what you name it (for information on modelines,
+read |modeline|). If modelines are disabled in your configuration, you may
+want to use another method to conveniently re-set the filetype of your
+Quicktask files. One common way to achieve that is with a file extension
 autocommand (see |autocommand|).
 
-For example, to make all files named *.quicktask open as Quicktask files, add 
+For example, to make all files named *.quicktask open as Quicktask files, add
 this line to your .vimrc: >
 	autocmd BufNewFile,BufRead *.quicktask setf quicktask
 >
-This tells Vim that when opening a new file or reading in a new buffer, if the 
+This tells Vim that when opening a new file or reading in a new buffer, if the
 filename matches *.quicktask, set the filetype to quicktask (see |setf|).
 
 ===============================================================================
 9. Known Issues					*quicktask-known-issues*
 
-Quicktask is a labor of love and a side project. As such, there are some 
-problems, and I know about most of them. So far, the issues haven't been so 
+Quicktask is a labor of love and a side project. As such, there are some
+problems, and I know about most of them. So far, the issues haven't been so
 great as to stop me from using Quicktask long enough to fix them, but...
 
-If you want to take a stab at it, by all means, send me a pull request on 
-Github (http://github.com/aaronbieber/quicktask.git) or get in touch with me 
+If you want to take a stab at it, by all means, send me a pull request on
+Github (http://github.com/aaronbieber/quicktask.git) or get in touch with me
 directly via e-mail at aaron 'at' aaronbieber.com.
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/ftplugin/quicktask.vim
+++ b/ftplugin/quicktask.vim
@@ -6,17 +6,17 @@
 "
 " See the documentation in doc/quicktask.txt
 "
-" Quicktask is free software: you can redistribute it and/or modify it under 
-" the terms of the GNU General Public License as published by the Free 
-" Software Foundation, either version 3 of the License, or (at your option) 
+" Quicktask is free software: you can redistribute it and/or modify it under
+" the terms of the GNU General Public License as published by the Free
+" Software Foundation, either version 3 of the License, or (at your option)
 " any later version.
-" 
-" Quicktask is distributed in the hope that it will be useful, but WITHOUT ANY 
-" WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-" FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more 
+"
+" Quicktask is distributed in the hope that it will be useful, but WITHOUT ANY
+" WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+" FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 " details.
-" 
-" You should have received a copy of the GNU General Public License along with 
+"
+" You should have received a copy of the GNU General Public License along with
 " Quicktask.  If not, see <http://www.gnu.org/licenses/>.
 
 " Compatibility option reset: {{{1
@@ -35,7 +35,7 @@ setlocal expandtab
 setlocal shiftwidth=2
 setlocal tabstop=2
 
-" Add the 'at' sign to the list of keyword characters so that our 
+" Add the 'at' sign to the list of keyword characters so that our
 " abbreviations may use it.
 setlocal iskeyword=@,@-@,48-57,_,192-255
 
@@ -117,7 +117,7 @@ endif
 " ============================================================================
 " GetAnyIndent(): Get the indent of any line. {{{1
 "
-" With the cursor on any line, return the indent level (the number of spaces 
+" With the cursor on any line, return the indent level (the number of spaces
 " at the beginning of the line, simply).
 function! s:GetAnyIndent()
 	" What is the indentation level of this task?
@@ -161,9 +161,9 @@ endfunction
 " ============================================================================
 " FindTaskEnd(): Find the end of the current task. {{{1
 "
-" Search forward for the end of the current task. If we do not start on a task 
-" line, we first search backwards for a task line. We then search forward for 
-" the first line that isn't a part of that task, which may be the next task, 
+" Search forward for the end of the current task. If we do not start on a task
+" line, we first search backwards for a task line. We then search forward for
+" the first line that isn't a part of that task, which may be the next task,
 " the next section, or the end of the file.
 function! s:FindTaskEnd(move)
 	" If we are not on a task line
@@ -183,7 +183,7 @@ function! s:FindTaskEnd(move)
 	endif
 
 	if a:move
-		" Move the cursor to the line immediately prior, which should be the 
+		" Move the cursor to the line immediately prior, which should be the
 		" last line of the task we are looking for.
 		call cursor(task_end_line-1, 0)
 	else
@@ -194,7 +194,7 @@ endfunction
 " ============================================================================
 " FindTaskParent(): Find the start line of the current task's parent. {{{1
 "
-" Get the indent level of the current task and, if non-zero, find the first 
+" Get the indent level of the current task and, if non-zero, find the first
 " line of the task that encloses this one (its 'parent').
 function! s:FindTaskParent()
 	call s:FindTaskStart(1)
@@ -212,21 +212,21 @@ endfunction!
 " ============================================================================
 " FindNextSibling(): Find the sibling task below the current task. {{{1
 "
-" Get the indent level of the current task and find a task below this one that 
-" has the same indent. If the current task is a child, only find siblings 
+" Get the indent level of the current task and find a task below this one that
+" has the same indent. If the current task is a child, only find siblings
 " within the same parent.
 function! s:FindNextSibling()
 	call s:FindTaskStart(1)
 	let indent = s:GetTaskIndent()
 
-	" If we might be a child, get the location of the next line 'below' our 
-	" indent level, such as our parent's next sibling. This is our 'boundary 
+	" If we might be a child, get the location of the next line 'below' our
+	" indent level, such as our parent's next sibling. This is our 'boundary
 	" line', beyond which we cannot search for siblings.
 	if indent > 0
 		let parent_indent = indent - &tabstop
 		let boundary_line = search('^\s\{0,'.parent_indent.'}[^ ]', 'nW')
 	else
-		" If we are at the lowest indent level, our boundary is the end of the 
+		" If we are at the lowest indent level, our boundary is the end of the
 		" file.
 		let boundary_line = line('$')
 	endif
@@ -237,19 +237,19 @@ endfunction
 " ============================================================================
 " FindPrevSibling(): Find the sibling task above the current task. {{{1
 "
-" Get the indent level of the current task and find a task above this one that 
-" has the same indent. If the current task is a child, only find siblings 
+" Get the indent level of the current task and find a task above this one that
+" has the same indent. If the current task is a child, only find siblings
 " within the same parent.
 function! s:FindPrevSibling()
 	call s:FindTaskStart(1)
 	let indent = s:GetTaskIndent()
 
-	" If we are a child of something, find the boundary at which we must stop 
+	" If we are a child of something, find the boundary at which we must stop
 	" searching. For backwards searching, this is our parent task's line.
 	if indent > 0
 		let boundary_line = s:FindTaskParent()
 	else
-		" If we are at the lowest indent level, our boundary is the beginning 
+		" If we are at the lowest indent level, our boundary is the beginning
 		" of the file.
 		let boundary_line = 1
 	endif
@@ -296,7 +296,7 @@ function! s:MakeSnipName()
 		endif
 	endif
 
-	" If we couldn't get an adequate string automatically, prompt the user for 
+	" If we couldn't get an adequate string automatically, prompt the user for
 	" one.
 	if !strlen(task_string)
 		echo "The task's name is not long enough or couldn't be found."
@@ -318,7 +318,7 @@ endfunction
 " ============================================================================
 " AddTask(after, indent): Add a task to the file. {{{1
 "
-" Add a 'skeleton' task to the file after the line given and at the indent 
+" Add a 'skeleton' task to the file after the line given and at the indent
 " level specified.
 function! s:AddTask(after, indent, move_cursor)
 	if a:indent > 0
@@ -353,14 +353,14 @@ function! s:AddTaskAbove()
 	let indent = s:GetTaskIndent()
 	" Append the new task above this line
 	let task_line_num = line('.')
-	
+
 	" Append the task, moving the cursor and starting insert
 	call s:AddTask(task_line_num-1, indent, 1)
 endfunction
 
 " ============================================================================
 " AddTaskBelow(): Add a task below the current task. {{{1
-" 
+"
 " Add a task below the current task, at the current task's level.
 function! s:AddTaskBelow()
 	" We insert directly below sections.
@@ -443,18 +443,18 @@ function! s:MoveTaskUp()
 		return
 	endif
 
-	" Move the cursor to the task line that we are moving and get the line 
+	" Move the cursor to the task line that we are moving and get the line
 	" number and indent level.
 	call s:FindTaskStart(1)
 	let task_start = line('.')
 	let indent = s:GetTaskIndent()
 
-	" If we are a child of something, anything, make sure we don't try to move 
+	" If we are a child of something, anything, make sure we don't try to move
 	" our child task into another task.
 	if indent > 0
 		" __Find the task above us, that we would move beyond ("sibling").__
-		" Start the search in the first column because backwards search will 
-		" match on the current line if the match is prior to the cursor 
+		" Start the search in the first column because backwards search will
+		" match on the current line if the match is prior to the cursor
 		" position.
 		call cursor(task_start, 0)
 		let prev_sibling_line = search('^\s\{'.indent.'}-', 'bnW')
@@ -465,7 +465,7 @@ function! s:MoveTaskUp()
 		" Find the parent line.
 		let parent_line = search('^\s\{'.parent_indent.'}-', 'bnW')
 
-		" If the previous sibling is before the parent line in the file then 
+		" If the previous sibling is before the parent line in the file then
 		" we should not move this task! Display a warning and abort.
 		if parent_line > prev_sibling_line
 			call s:EchoWarning("You can't move a task out of its parent task; use normal delete/put to move it.")
@@ -507,7 +507,7 @@ endfunction
 " ============================================================================
 " AddSnipToTask(): Add a new snip to a task as a note. {{{1
 "
-" Add a new snip (external note) to a task. This will be overhauled in 2.0 
+" Add a new snip (external note) to a task. This will be overhauled in 2.0
 " when snips are in external files.
 function! s:AddSnipToTask()
 	" Make sure we are properly configured to use snips.
@@ -537,7 +537,7 @@ function! s:AddSnipToTask()
 				" Insert the snip above
 				let snip_line = current_line - 1
 				break
-			elseif match(getline(current_line), '\vAdded \[') > -1 || 
+			elseif match(getline(current_line), '\vAdded \[') > -1 ||
 				  \match(getline(current_line), '\vStart \[') > -1 ||
 				  \match(getline(current_line), '\v\[\$:') > -1
 
@@ -547,11 +547,11 @@ function! s:AddSnipToTask()
 			else
 				let snip_line = current_line - 1
 				break
-				" If it matches something else, like a plain note, insert the 
+				" If it matches something else, like a plain note, insert the
 				" snip above.
 			endif
 		else
-			" This is the line beyond the task; the line above is the one we 
+			" This is the line beyond the task; the line above is the one we
 			" want.
 			let snip_line = current_line - 1
 			break
@@ -687,7 +687,7 @@ function! s:AddStartTimeToTask(start, indent)
 
 	call append(a:start, physical_indent."* Start ".today." ".now)
 
-	" If the current line is a task line, we have to indent the start time. If 
+	" If the current line is a task line, we have to indent the start time. If
 	" not, then we don't.
 	"if match(getline('.'), '\v^\s*-') > -1
 	"	exe "normal! o\<Tab>* Start ".today." ".now."\<Esc>"
@@ -699,7 +699,7 @@ endfunction
 " ============================================================================
 " AddEndTimeToTask(): Add the end time to an existing start time. {{{1
 "
-" Called by AddNextTimeToTask() to append an end time to an existing start 
+" Called by AddNextTimeToTask() to append an end time to an existing start
 " time note.
 function! s:AddEndTimeToTask(start, indent)
 	" Place the cursor at the given start line.
@@ -717,7 +717,7 @@ endfunction
 " ============================================================================
 " TaskComplete(): Mark a task as complete (DONE). {{{1
 "
-" Mark a task as complete by placing a note at the very end of the task 
+" Mark a task as complete by placing a note at the very end of the task
 " containing the keyword DONE followed by the current timestamp.
 function! s:TaskComplete()
 	" If we are not on a task line right now, we need to search up for one.
@@ -730,9 +730,9 @@ function! s:TaskComplete()
 	" indent (the number of spaces in the user's tabstop).
 	let indent = indent + &tabstop
 
-	" Search downward, looking for either a reduction in the indentation level 
-	" or the end of the file. The first line to fail to match will be the line 
-	" AFTER our insertion point. Start searching on the line after the task 
+	" Search downward, looking for either a reduction in the indentation level
+	" or the end of the file. The first line to fail to match will be the line
+	" AFTER our insertion point. Start searching on the line after the task
 	" line.
 	let current_line = line('.') + 1
 	let matched = 0
@@ -750,7 +750,7 @@ function! s:TaskComplete()
 
 	" Create the timestamp.
 	let today = '['.strftime("%a %Y-%m-%d").']'
-	
+
 	" Save the contents of register 'a'.
 	" let old_a = @a
 	" Create the DONE line and save it in register 'a'.
@@ -766,7 +766,7 @@ endfunction
 " ============================================================================
 " SaveOnFocusLost(): Save the current file silently. {{{1
 "
-" This will be called by an autocommand to save the current task list file 
+" This will be called by an autocommand to save the current task list file
 " when focus is lost.
 function! s:SaveOnFocusLost()
 	if &filetype == "quicktask"
@@ -776,10 +776,10 @@ endfunction
 
 " ============================================================================
 " GetDatestamp(): Get a Quicktask-formatted datestamp. {{{1
-" 
-" Datestamps are used throughout Quicktask both for user convenience of 
-" tracking their tasks in the continuum of the universe immemorial and also to 
-" locate current tasks. GetDatestamp() returns a Quicktask-formatted 
+"
+" Datestamps are used throughout Quicktask both for user convenience of
+" tracking their tasks in the continuum of the universe immemorial and also to
+" locate current tasks. GetDatestamp() returns a Quicktask-formatted
 " datestamp for the requested time relative to 'now.'
 function! s:GetDatestamp(coordinate)
 	if a:coordinate == 'today'
@@ -799,8 +799,8 @@ endfunction
 " ============================================================================
 " GetTimestamp(): Get a Quicktask-formatted timestamp. {{{1
 "
-" Timestamps are used for the start and end times added to tasks and by the 
-" abbreviation system. GetTimestamp() returns a Quicktask-formatted timestamp 
+" Timestamps are used for the start and end times added to tasks and by the
+" abbreviation system. GetTimestamp() returns a Quicktask-formatted timestamp
 " for the current time.
 function! s:GetTimestamp()
 	return '['.strftime('%H:%M').']'
@@ -809,7 +809,7 @@ endfunction
 " ============================================================================
 " QTFoldLevel(): Returns the fold level of the current line. {{{1
 "
-" This is used by the Vim folding system to fold tasks based on their depth 
+" This is used by the Vim folding system to fold tasks based on their depth
 " and relationship to one another.
 function! QTFoldLevel(linenum)
 	let pre_indent = indent(a:linenum-1) / &tabstop
@@ -879,8 +879,8 @@ endfunction
 " ============================================================================
 " QTFoldText(): Provide the text displayed on a fold when closed. {{{1
 "
-" This is used by the Vim folding system to find the text to display on fold 
-" headings when folds are closed. We use this to cause the headings to display 
+" This is used by the Vim folding system to find the text to display on fold
+" headings when folds are closed. We use this to cause the headings to display
 " in an indented fashion matching the tasks themselves.
 function! QTFoldText()
 	let lines = v:foldend - v:foldstart + 1
@@ -891,7 +891,7 @@ endfunction
 " ============================================================================
 " CloseFoldIfOpen(): Quietly close a fold only if it is open. {{{1
 "
-" This is used when automatically opening and closing folded tasks based on 
+" This is used when automatically opening and closing folded tasks based on
 " their status.
 function! CloseFoldIfOpen()
 	if foldclosed(line('.')) == -1
@@ -902,7 +902,7 @@ endfunction
 " ============================================================================
 " OpenFoldIfClosed(): Quietly open a fold only if it is closed. {{{1
 "
-" This is used when automatically opening and closing folded tasks based on 
+" This is used when automatically opening and closing folded tasks based on
 " their status.
 function! OpenFoldIfClosed()
 	if foldclosed(line('.')) > -1
@@ -913,7 +913,7 @@ endfunction
 " ============================================================================
 " ShowActiveTasksOnly(): Fold all completed tasks. {{{1
 "
-" The net result is that only incomplete (active) tasks remain open and 
+" The net result is that only incomplete (active) tasks remain open and
 " visible in the list.
 function! s:ShowActiveTasksOnly()
 	let current_line = line('.')
@@ -931,7 +931,7 @@ endfunction
 " ============================================================================
 " ShowWatchedTasksOnly(): Fold all except watched tasks. {{{1
 "
-" The net result is that only tasks that you are watching (containing "WATCH" 
+" The net result is that only tasks that you are watching (containing "WATCH"
 " remain open and visible in the list.
 function! s:ShowWatchedTasksOnly()
 	let current_line = line('.')
@@ -943,9 +943,9 @@ endfunction
 " ============================================================================
 " FindIncompleteTimestamps(): Execute a search for incomplete timestamps. {{{1
 "
-" This function only sets the forward search pattern. It is called from a 
-" command that forces hlsearch to "on", which has the effect of highlighting 
-" any timestamp notes that have start times and no end times (presumably 
+" This function only sets the forward search pattern. It is called from a
+" command that forces hlsearch to "on", which has the effect of highlighting
+" any timestamp notes that have start times and no end times (presumably
 " beceause you forgot to end them or they are still pending).
 function! s:FindIncompleteTimestamps()
 	let @/ = '\*\sStart\s\[\w\w\w\s\d\d\d\d-\d\d-\d\d\]\s\[\d\d:\d\d\]$'

--- a/plugin/quicktask.vim
+++ b/plugin/quicktask.vim
@@ -6,17 +6,17 @@
 "
 " See the documentation in doc/quicktask.txt
 "
-" Quicktask is free software: you can redistribute it and/or modify it under 
-" the terms of the GNU General Public License as published by the Free 
-" Software Foundation, either version 3 of the License, or (at your option) 
+" Quicktask is free software: you can redistribute it and/or modify it under
+" the terms of the GNU General Public License as published by the Free
+" Software Foundation, either version 3 of the License, or (at your option)
 " any later version.
-" 
-" Quicktask is distributed in the hope that it will be useful, but WITHOUT ANY 
-" WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-" FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more 
+"
+" Quicktask is distributed in the hope that it will be useful, but WITHOUT ANY
+" WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+" FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 " details.
-" 
-" You should have received a copy of the GNU General Public License along with 
+"
+" You should have received a copy of the GNU General Public License along with
 " Quicktask.  If not, see <http://www.gnu.org/licenses/>.
 
 " Set all buffer-local settings: {{{1

--- a/syntax/quicktask.vim
+++ b/syntax/quicktask.vim
@@ -4,23 +4,23 @@
 " Version:	1.2
 " Date:		10 January 2012
 "
-" This syntax file was based upon the work of Eric Talevich in his 
-" "todolist" syntax format. Though many patterns have been re-worked, Eric's 
+" This syntax file was based upon the work of Eric Talevich in his
+" "todolist" syntax format. Though many patterns have been re-worked, Eric's
 " base file was the inspiration that made Quicktask possible.
 "
 " See the documentation in doc/quicktask.txt
 "
-" Quicktask is free software: you can redistribute it and/or modify it under 
-" the terms of the GNU General Public License as published by the Free 
-" Software Foundation, either version 3 of the License, or (at your option) 
+" Quicktask is free software: you can redistribute it and/or modify it under
+" the terms of the GNU General Public License as published by the Free
+" Software Foundation, either version 3 of the License, or (at your option)
 " any later version.
-" 
-" Quicktask is distributed in the hope that it will be useful, but WITHOUT ANY 
-" WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-" FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more 
+"
+" Quicktask is distributed in the hope that it will be useful, but WITHOUT ANY
+" WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+" FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 " details.
-" 
-" You should have received a copy of the GNU General Public License along with 
+"
+" You should have received a copy of the GNU General Public License along with
 " Quicktask.  If not, see <http://www.gnu.org/licenses/>.
 
 if exists("b:current_syntax")


### PR DESCRIPTION
I configured vim to highlight trailing whitespace by default, so looking
at the :help is painful then. And trailing WS is a minor anti-pattern.
