### PR TITLE
Create a new buffer if the current one if !&modifiable

### DIFF
--- a/plugin/quicktask.vim
+++ b/plugin/quicktask.vim
@@ -27,7 +27,7 @@ let s:version = '1.2'
 "
 " Create a new Quicktask file in a new buffer.
 function! QTInit()
-    if len(expand('%:p')) || &modified
+    if len(expand('%:p')) || &modified || !&modifiable
         execute "new"
     endif
     setlocal filetype=quicktask


### PR DESCRIPTION
Fixes the following error when using `:QTInit` in a non-writable buffer:

```
Error detected while processing function QTInit:
line   13:
line   14:
E21: Cannot make changes, 'modifiable' is off
E21: Cannot make changes, 'modifiable' is off
```
