### PR TITLE
Add boilerplate for ftplugins

### DIFF
--- a/ftplugin/quicktask.vim
+++ b/ftplugin/quicktask.vim
@@ -1077,7 +1077,10 @@ endif
 " ============================================================================
 " Autocommands {{{1
 if g:quicktask_autosave
-    autocmd BufLeave,FocusLost * call <SID>SaveOnFocusLost()
+    augroup quicktask
+      au!
+      autocmd BufLeave,FocusLost * call <SID>SaveOnFocusLost()
+    augroup END
 endif
 
 " ============================================================================


### PR DESCRIPTION
This prevents the file from being sourced multiple times.

This is good for performance and fixes possible errors because of the
`<unique` maps. This happened to me after an initial `:QTInit`.
