### PR TITLE
Include digits in snip filename

### DIFF
--- a/ftplugin/quicktask.vim
+++ b/ftplugin/quicktask.vim
@@ -323,7 +323,7 @@ function! s:MakeSnipName()
     if !strlen(task_string)
         echo "The task's name is not long enough or couldn't be found."
         let orig_text = input("Enter a name for the snip: ")
-        let task_string = tolower(substitute(orig_text, '[^a-zA-Z]', '-', 'g'))
+        let task_string = tolower(substitute(orig_text, '[^a-zA-Z0-9]', '-', 'g'))
         if strlen(task_string) > 30
             let task_string = matchstr(task_string, '^\(.\{15\}\)')
         endif


### PR DESCRIPTION
Just started using this plugin to track dev work that includes tasks with the ticket number. The snip filename was ending up with `---` on the end leaving out the ticket number. This small change seems to resolve the issue but I didn't test much more than trying it out myself.